### PR TITLE
Unify install instructions and add Twitter details

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,14 @@
-# Create S3 bucket
+# Setup thingsleilasays
+
+## Create Heroku app
+
+Create a heroku app:
+
+```bash
+heroku create thingsleilasays
+```
+
+## Create S3 bucket
 
 Setup the AWS CLI:
 
@@ -6,7 +16,7 @@ Setup the AWS CLI:
 aws configure
 ```
 
-## Create a new S3 bucket for tweets
+### Create a new S3 bucket for tweets
 
 Create a new bucket in us-east-1:
 
@@ -37,7 +47,7 @@ aws s3api put-bucket-lifecycle-configuration --bucket thingsleilasays --lifecycl
 }'
 ```
 
-## Create an IAM user and IAM profile for access to S3
+### Create an IAM user and IAM profile for access to S3
 
 Create a new IAM user for the thingsleilasays app:
 
@@ -79,7 +89,7 @@ to the `thingsleilasays` IAM user:
 aws iam list-user-policies --user-name thingsleilasays
 ```
 
-## Create credentials and setup thingsleilasays to use them
+### Create credentials and setup thingsleilasays to use them
 
 Create an access key for the `thingsleilasays` user:
 
@@ -88,7 +98,7 @@ aws iam create-access-key --user-name thingsleilasays
 ```
 
 Copy the access key ID and the secret access key and set them as config vars
-on the `thingsleilasays` service:
+on the `thingsleilasays` app:
 
 ```bash
 heroku config:set -a thingsleilasays \
@@ -99,3 +109,41 @@ heroku config:set -a thingsleilasays \
 
 At this point the `thingsleilasays` app should have access to the read and
 write tweets to the S3 bucket.
+
+## Create Twitter app
+
+Login to Twitter, go to https://apps.twitter.com and click *Create New App*.
+
+### Create app
+
+Fill the form, check the developer agreement box and click *Create your
+Twitter application*.
+
+### Setup permissions
+
+Visit the app and click on the *Permissions* tab. Select *Read only* and click
+*Update Settings*.
+
+### Fetch access tokens
+
+CLick on the *Keys and Access Tokens* tab. Copy the consumer key, consumer
+secret, access token and access token secret and set them as config vars on
+the `thingsleilasays` app:
+
+```bash
+heroku config:set -a thingsleilasays \
+    TWITTER_CONSUMER_KEY=$CONSUMER_KEY \
+    TWITTER_CONSUMER_SECRET=$CONSUMER_SECRET \
+    TWITTER_ACCESS_TOKEN=$ACCESS_TOKEN \
+    TWITTER_ACCESS_SECRET=$ACCESS_TOKEN_SECRET \
+    TWITTER_USERNAME=$USERNAME
+```
+
+## Deploy Heroku app
+
+Push the code to Heroku and scale a web dyno
+
+```bash
+git push heroku master
+heroku scale web=1:Free
+```


### PR DESCRIPTION
A new `docs/install.md` combined previous AWS instructions with more complete instructions that describe setting up a Heroku account and a Twitter app.